### PR TITLE
Add event "START_TRAINING"

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+from typing import ClassVar
 import logging
 import os
 import random
@@ -44,7 +45,7 @@ logger.setLevel(logging.DEBUG)
 
 
 class SpacyModel(LabelStudioMLBase):
-    TRAIN_EVENTS = ()
+    TRAIN_EVENTS: ClassVar[tuple[str]] = ("START_TRAINING",)
 
     def __init__(self, **kwargs):
         super(SpacyModel, self).__init__(**kwargs)


### PR DESCRIPTION
This solves #4 .

Label Studio stopped using the /train endpoint from version 1.4.1, and switched to using the /webhooks endpoint. The TRAIN_EVENTS class variable decides which kind events sent to the /webhooks endpoint should start a new fit. Since the TRAIN_EVENTS list is empty, no training is started if you run SpacyModel with Label Studio 1.4.1 or newer.
